### PR TITLE
deploy: fix 404 on routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY . ./
 # Build the dist
 RUN npm run build
 
+# DEPLOY THE NGINX conf file as default APLINE config returns everything as a 404
+RUN cp /root/portfolio/server.conf /etc/nginx/conf.d/default.conf
+
 # Copy built files to NGINX htdocs directory
 RUN rm -rf /usr/share/nginx/html/*
 RUN cp -rf /root/portfolio/dist/* /usr/share/nginx/html/

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,16 @@
+server {
+	listen 80;
+	listen [::]:80;
+
+	root /usr/share/nginx/html;
+
+	index index.html;
+
+	location / {
+		try_files $uri $uri/ /index.html;
+	}
+
+	location ~ /\.ht {
+		deny all;
+	}
+}


### PR DESCRIPTION
Nginx default config returns 404 on all routes
that are to be handled server side.

This patch replaces the config with a suitable one.